### PR TITLE
Algorithm Revamp

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,5 @@
-import { Pixel, Colors } from "./pixel";
-import { pixelTrueColor } from "./util";
+import { Colors } from "./pixel";
 import { Board } from "./board";
-import { basename } from "path";
 
 interface Branch {
   score: number;
@@ -12,19 +10,6 @@ let board = new Board();
 
 board.setupBoard();
 board.printBoard();
-board.mosaics.forEach((m) => {
-  if (m[0].color === m[1].color) {
-    console.log(
-      pixelTrueColor(m[0].color, false) +
-        m.map((p) => `${p.y},${p.x}`).join(" ")
-    );
-  } else {
-    console.log(
-      pixelTrueColor(m[0].color, false) +
-        m.map((p) => `${pixelTrueColor(p.color, false)}${p.y},${p.x}`).join(" ")
-    );
-  }
-});
 
 console.log();
 console.log("Total:", board.getScore());
@@ -41,17 +26,13 @@ const getHighestScore = (
   history: PixelData[],
   transpositionTable: Map<string, Branch>
 ): Branch => {
-  const boardKey = board.hash(); // Generate a unique key for the current board state
+  const boardKey = board.hash();
 
-  // Check if the board state is already in the transposition table
   if (transpositionTable.has(boardKey)) {
-    // console.log("Found in transposition table");
     return transpositionTable.get(boardKey) as Branch;
   }
 
   if (depth == 0) {
-    // board.printBoard();
-    // console.log("Total:", board.getScore());
     return {
       score: board.getScore(),
       moves: [...history],
@@ -60,20 +41,8 @@ const getHighestScore = (
   const moves = board.getMoves();
   let maxScore: Branch = { score: -Infinity, moves: [] };
   moves.forEach((move) => {
-    for (const color of [
-      Colors.White,
-      Colors.Yellow,
-      Colors.Green,
-      Colors.Purple,
-    ]) {
-      // const copy = board.copy();
-      // copy.pixels[move.y][move.x].color = color;
+    for (let color = Colors.White; color <= Colors.Purple; color++) {
       board.pixels[move.y][move.x].color = color;
-      // const historyCopy = [];
-      // history.forEach((h) =>
-      //   historyCopy.push({ color: h.color, x: h.x, y: h.y })
-      // );
-      // historyCopy.push({ color, x: move.x, y: move.y });
       history.push({ color, x: move.x, y: move.y });
       const b = getHighestScore(board, depth - 1, history, transpositionTable);
       board.pixels[move.y][move.x].color = Colors.Empty;
@@ -81,7 +50,6 @@ const getHighestScore = (
       if (b.score > maxScore.score) {
         maxScore = b;
       }
-      // console.log(b);
     }
   });
   transpositionTable.set(boardKey, maxScore);
@@ -89,14 +57,14 @@ const getHighestScore = (
 };
 
 const start = Date.now();
-const top = getHighestScore(board, 5, [], new Map());
-console.log("Top", top.score);
+const top = getHighestScore(board, 4, [], new Map());
+const end = Date.now();
 const newBoard = board.copy();
+newBoard.printBoard();
+console.log("Top", top.score);
+console.log("Time:", end - start);
 top.moves.forEach((m) => {
   6;
   console.log(`${m.y},${m.x} ${m.color}`);
   newBoard.pixels[m.y][m.x].color = m.color;
 });
-newBoard.printBoard();
-const end = Date.now();
-console.log("Time:", end - start);


### PR DESCRIPTION
Fix issues of the base algorithm (do not evaluate the score for every node, but only the end nodes).
Added Transposition Table.
Instead of copy the table for each node, you instead simply toggle the state of each pixel for that node and toggle it off.
Numerous other performance gains.
Other small bug fixes.

Runtime down to `400-500ms` with vscode and `200ms` with direct run.