### PR TITLE
Multi Color Node Elimination

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import { Colors } from "./pixel";
+import { Colors, PixelData } from "./pixel";
 import { Board } from "./board";
 
 interface Branch {
@@ -14,12 +14,6 @@ board.printBoard();
 console.log();
 console.log("Total:", board.getScore());
 
-interface PixelData {
-  color: number;
-  x: number;
-  y: number;
-}
-
 const getHighestScore = (
   board: Board,
   depth: number,
@@ -33,15 +27,25 @@ const getHighestScore = (
   }
 
   if (depth == 0) {
+    const score = board.getScore();
+    if (score.color.length !== 0) {
+      for (const c of score.color) {
+        // console.log(`${c.y},${c.x} ${c.color}`);
+        const hC = history.find((h) => h.x === c.x && h.y === c.y);
+        if (hC) {
+          hC.color = c.color;
+        }
+      }
+    }
     return {
-      score: board.getScore(),
+      score: score.score,
       moves: [...history],
     };
   }
   const moves = board.getMoves();
   let maxScore: Branch = { score: -Infinity, moves: [] };
   moves.forEach((move) => {
-    for (let color = Colors.White; color <= Colors.Purple; color++) {
+    for (let color = Colors.White; color <= Colors.Yellow; color++) {
       board.pixels[move.y][move.x].color = color;
       history.push({ color, x: move.x, y: move.y });
       const b = getHighestScore(board, depth - 1, history, transpositionTable);
@@ -57,7 +61,7 @@ const getHighestScore = (
 };
 
 const start = Date.now();
-const top = getHighestScore(board, 4, [], new Map());
+const top = getHighestScore(board, 8, [], new Map());
 const end = Date.now();
 const newBoard = board.copy();
 top.moves.forEach((m) => {

--- a/index.ts
+++ b/index.ts
@@ -60,11 +60,12 @@ const start = Date.now();
 const top = getHighestScore(board, 4, [], new Map());
 const end = Date.now();
 const newBoard = board.copy();
-newBoard.printBoard();
-console.log("Top", top.score);
-console.log("Time:", end - start);
 top.moves.forEach((m) => {
   6;
   console.log(`${m.y},${m.x} ${m.color}`);
   newBoard.pixels[m.y][m.x].color = m.color;
 });
+
+newBoard.printBoard();
+console.log("Top", top.score);
+console.log("Time:", end - start);

--- a/pixel.ts
+++ b/pixel.ts
@@ -1,6 +1,12 @@
 import { Board } from "./board";
 import { pixelTrueColor, trueColor, resetCode } from "./util";
 
+export interface PixelData {
+  color: number;
+  x: number;
+  y: number;
+}
+
 export class Pixel {
   private offsets: number[][];
 


### PR DESCRIPTION
Instead of calculating every color every time for each node, we only calculate whether it's a white or colored (yellow, green, or purple, we use yellow as a placeholder, you could also prob use a custom color placeholder but eh). Then in the different color mosaics' calculator, we would then check if there's a case where it's 2 yellows and one other color. We would then create an array of such instances and stored the x, y, and what color it would have to be in order to have a mixed mosaic. We then just modified the color in the history array. 

After the changes, the runtime for a depth of 4 goes from `250-300ms` via direct run and `500-550ms` via vscode down to `35-45ms` via direct run and `50-70ms` for vscode. For `~1-1.5s` via direct run, we can now go down to a depth of 8 rather than 5.

Also fixed a small bug where the final board population for printing based of history was actually done after we printed the board already.